### PR TITLE
Enhance dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ uv venv
 
 ## Easy Mode
 
-Asumes, your are running a tmux session with 3 taranis-ai windows already, 
-creates 2 additional windows for tailwind & flask.
+Asumes, your are running a tmux session with taranis-ai windows already (named 'taranis'),   
+creates 2 additional tmux windows for tailwind & flask.
 
 ```bash
 ./start_dev.sh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv
 ```
 
+## Easy Mode
+
+Asumes, your are running a tmux session with 3 taranis-ai windows already, 
+creates 2 additional windows for tailwind & flask.
+
+```bash
+./start_dev.sh
+```
+
+## Hard Mode
+
 Source venv and install dependencies
 
 ```bash
@@ -57,7 +68,7 @@ Run the Flask development server:
 flask run
 ```
 
-This will start the Flask server and run the scheduler service at `http://localhost:5000`.
+This will start the Flask server and run the scheduler service at `http://localhost:5001`.
 
 ---
 
@@ -86,14 +97,14 @@ Configuration is handled via environment variables.
 
 ### Required Environment Variables
 
-- **`SQLALCHEMY_DATABASE_URI`**: The connection string to your PostgreSQL database.
-  - Example: `postgresql://username:password@localhost:5432/your_database`
-  
 - **`FLASK_ENV`**: Set to `development` or `production`.
   - Example: `export FLASK_ENV=development`
 
 - **`FLASK_APP`**: Set this to the name of your app (e.g., `scheduler`).
   - Example: `export FLASK_APP=scheduler`
 
-- **`JWT_SECRET_KEY`**: The secret key for signing JWT tokens.
-  - Example: `export JWT_SECRET_KEY=your-secret-key`
+- **`TARANIS_CORE_URL`**: The URL from the core service  
+  - Example: `export TARANIS_CORE_URL="http://local.taranis.ai/api"`
+
+- **`APPLICATION_ROOT`**
+  - Example: `export APPLICATION_ROOT="/scheduler"`

--- a/env.sample
+++ b/env.sample
@@ -1,3 +1,5 @@
-FLASK_RUN_PORT=8088
+FLASK_RUN_PORT=5001
 FLASK_DEBUG=True
 DEBUG=True
+TARANIS_CORE_URL="http://local.taranis.ai/api"
+APPLICATION_ROOT="/scheduler"

--- a/extend_tmux.sh
+++ b/extend_tmux.sh
@@ -5,9 +5,9 @@ set -eu
 cd $(git rev-parse --show-toplevel)
 
 # Create tailwind tab
-tmux new-window -t taranis:3 -n tailwind 
+tmux new-window -t taranis -n tailwind 
 tmux send-keys -t taranis:tailwind "./tailwindcss -i scheduler/static/css/input.css -o scheduler/static/css/tailwind.css --watch" C-m
 
 # Create scheduler tab
-tmux new-window -t taranis:4 -n scheduler 
+tmux new-window -t taranis -n scheduler 
 tmux send-keys -t taranis:scheduler "./install_and_run_dev.sh" C-m

--- a/extend_tmux.sh
+++ b/extend_tmux.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+cd $(git rev-parse --show-toplevel)
+
+# Create tailwind tab
+tmux new-window -t taranis:3 -n tailwind 
+tmux send-keys -t taranis:tailwind "./tailwindcss -i scheduler/static/css/input.css -o scheduler/static/css/tailwind.css --watch" C-m
+
+# Create scheduler tab
+tmux new-window -t taranis:4 -n scheduler 
+tmux send-keys -t taranis:scheduler "./install_and_run_dev.sh" C-m

--- a/install_and_run_dev.sh
+++ b/install_and_run_dev.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -eu
+
+if [ ! -d ".venv" ]; then
+    uv venv
+    source .venv/bin/activate
+    uv pip install -e ."[dev]"
+fi
+
+source .venv/bin/activate
+
+python -m flask run
+

--- a/scheduler/config.py
+++ b/scheduler/config.py
@@ -19,8 +19,8 @@ class Settings(BaseSettings):
     GIT_INFO: dict[str, str] | None = None
     CACHE_TYPE: str = "SimpleCache"
     CACHE_DEFAULT_TIMEOUT: int = 300
-    TARANIS_CORE_URL: str = ""
-    TARANIS_CORE_HOST: str = "core:8080"
+    TARANIS_CORE_URL: str = "http://local.taranis.ai/api"
+    TARANIS_CORE_HOST: str = ""
     TARANIS_BASE_PATH: str = "/"
     SSL_VERIFICATION: bool = False
     REQUESTS_TIMEOUT: int = 60

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -1,0 +1,9 @@
+#!/bin/bash 
+
+set -eu 
+
+if [ ! -f ".env" ]; then
+    cp env.sample .env
+fi
+
+./extend_tmux.sh


### PR DESCRIPTION
1. create `start_dev.sh` like taranis-ai already has
2. introduce 'local.taranis.ai' as local dev project BASE_URL (similar PR in taranis-ai will follow soon)

`local.taranis.ai` resolves in 127.0.0.1 (see e.g. `dig local.taranis.ai` for yourself),
but it seems that some setups (e.g. fritzbox modem) block private IPs in dns.
(but maybe better in taranis-ai Readme)

We could add a hint in Readme for a `hosts file entry`, this should always work, regardless of any "dns rebind security features".