### PR TITLE
Add tailwind download, if necessary

### DIFF
--- a/extend_tmux.sh
+++ b/extend_tmux.sh
@@ -6,7 +6,7 @@ cd $(git rev-parse --show-toplevel)
 
 # Create tailwind tab
 tmux new-window -t taranis -n tailwind 
-tmux send-keys -t taranis:tailwind "./tailwindcss -i scheduler/static/css/input.css -o scheduler/static/css/tailwind.css --watch" C-m
+tmux send-keys -t taranis:tailwind "./install_and_run_tailwind.sh" C-m
 
 # Create scheduler tab
 tmux new-window -t taranis -n scheduler 

--- a/install_and_run_tailwind.sh
+++ b/install_and_run_tailwind.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eu
+
+if [ ! -d tailwindcss ]; then
+    curl -sLo tailwindcss https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64
+    chmod +x tailwindcss
+fi
+
+./tailwindcss -i scheduler/static/css/input.css -o scheduler/static/css/tailwind.css --watch


### PR DESCRIPTION
A new (shell-)script is added, which 

* checks if the current directory contains a file called 'tailwindcss', and downloads it, if not
* starts the tailwindcss executable (like before)